### PR TITLE
Support dynamic extra semantic release plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ Add this step to your GitHub workflow file:
   uses: fingerprintjs/action-semantic-release-info@v1
 ```
 
+### Inputs
+
+- `semanticReleasePlugins` (optional): Additional Semantic Release plugins to install and include. For example;
+  ```
+  - name: Collect semantic-release-info
+    id: semantic_release_info
+    uses: fingerprintjs/action-semantic-release-info@v1
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    with:
+      semanticReleasePlugins: |
+        @fingerprintjs/semantic-release-native-dependency-plugin@^1.2.1
+  ```
+
 ### Output Variables
 
 After the action is completed, you can access the output variables using this pattern:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: 'Semantic Release Preview'
 description: 'Action to get next semantic release info, does not publish. export the info as output variables'
 author: 'FingerprintJS'
+inputs:
+  semanticReleasePlugins:
+    description: 'Additional semantic release plugins'
+    default: ''
+    required: false
 outputs:
   type:
     description: 'The part of the version incremented - major/minor/patch'

--- a/exec.js
+++ b/exec.js
@@ -1,0 +1,22 @@
+const exec = require('child_process').exec;
+const path = require('path');
+
+function executeCommand(cmd, workingDirectory = null) {
+    return new Promise((resolve, reject) => {
+        let options = {};
+        if (workingDirectory) {
+            options.cwd = path.resolve(workingDirectory);
+        }
+        let p = exec(cmd, options, (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            }
+            resolve(stdout ? stdout : stderr);
+        });
+
+        p.stdout.pipe(process.stdout);
+        p.stderr.pipe(process.stderr);
+    });
+}
+
+module.exports.executeCommand = executeCommand;

--- a/index.js
+++ b/index.js
@@ -1,23 +1,4 @@
-const exec = require('child_process').exec;
-const path = require('path');
-
-function executeCommand(cmd, workingDirectory = null) {
-    return new Promise((resolve, reject) => {
-        let options = {};
-        if (workingDirectory) {
-            options.cwd = path.resolve(workingDirectory);
-        }
-        let p = exec(cmd, options, (error, stdout, stderr) => {
-            if (error) {
-                reject(error);
-            }
-            resolve(stdout ? stdout : stderr);
-        });
-
-        p.stdout.pipe(process.stdout);
-        p.stderr.pipe(process.stderr);
-    });
-}
+const { executeCommand } = require("./exec");
 
 async function main() {
     const currentBranch = process.env.GITHUB_HEAD_REF;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@actions/core": "^1.10.1",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
     "conventional-changelog-conventionalcommits": "^7.0.2",
+    "cosmiconfig": "^9.0.0",
     "semantic-release": "^19.0.5"
   },
   "license": "MIT"

--- a/plugin.js
+++ b/plugin.js
@@ -14,8 +14,12 @@ async function findPluginConfig(pluginName) {
         throw new Error(`Project semantic release config file not found.`);
     }
 
-    if (!config.plugins || !Array.isArray(config.plugins)) {
+    if (!config.plugins) {
         throw new Error(`Project release config file doesn't have plugins field.`);
+    }
+
+    if (!Array.isArray(config.plugins)) {
+        throw new Error(`Project release config file plugins field is not an array.`);
     }
 
     const pluginConfig = config.plugins.find(plugin => {

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,41 @@
+const cosmiconfig = require('cosmiconfig');
+
+function extractPluginName(pluginName) {
+    const atIndex = pluginName.lastIndexOf('@');
+    return atIndex !== -1
+        ? pluginName.substring(0, atIndex)
+        : pluginName;
+}
+
+async function findPluginConfig(pluginName) {
+    const { config } = await cosmiconfig.cosmiconfig('release').search();
+
+    if (!config) {
+        throw new Error(`Project semantic release config file not found.`);
+    }
+
+    if (!config.plugins || !Array.isArray(config.plugins)) {
+        throw new Error(`Project release config file doesn't have plugins field.`);
+    }
+
+    const pluginConfig = config.plugins.find(plugin => {
+        if (typeof plugin === 'string' && plugin !== pluginName) {
+            return false;
+        }
+
+        if (!Array.isArray(plugin) || plugin.length <= 1) {
+            return false;
+        }
+
+        if (plugin[0] !== pluginName) {
+            return false;
+        }
+
+        return true;
+    });
+
+    return pluginConfig ? pluginConfig[1] : {};
+}
+
+module.exports.findPluginConfig = findPluginConfig;
+module.exports.extractPluginName = extractPluginName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,11 @@ are-we-there-yet@^3.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 argv-formatter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
@@ -914,6 +919,16 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cosmiconfig@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
+  integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
+  dependencies:
+    env-paths "^2.2.1"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1054,7 +1069,7 @@ env-ci@^5.0.0:
     fromentries "^1.3.2"
     java-properties "^1.0.0"
 
-env-paths@^2.2.0:
+env-paths@^2.2.0, env-paths@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
@@ -1439,6 +1454,14 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-fresh@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 import-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
@@ -1629,6 +1652,13 @@ js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@1.1.0:
   version "1.1.0"
@@ -2522,7 +2552,7 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-json@^5.0.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==


### PR DESCRIPTION
Added a new input (`semanticReleasePlugins`) to allow specifying extra semantic-release plugins at runtime. These plugins are installed dynamically (with `yarn add`) based on workflow call. Added `cosmiconfig` dependency to read correct semantic release config file. Moved `executeCommand` into a separate file for reusability in `main.js` file.

Related-Task: INTER-1238